### PR TITLE
Add multi-platform build support (linux/amd64, linux/arm64)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,6 +20,12 @@ jobs:
       with:
         fetch-depth: '0'
 
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
     - name: Log in to the Container registry
       uses: docker/login-action@v3
       with:
@@ -34,9 +40,10 @@ jobs:
         images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
     - name: Build and push
-      uses: docker/build-push-action@v3
+      uses: docker/build-push-action@v6
       with:
         context: .
+        platforms: linux/amd64,linux/arm64
         push: true
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
ARM64 環境でも動作させたいため、Actions の Docker Build に  `platforms: linux/amd64,linux/arm64` を追加しました。

参考ドキュメント: [Multi-platform image with GitHub Actions](https://docs.docker.com/build/ci/github-actions/multi-platform/?utm_source=chatgpt.com)