### PR TITLE
get-entryでゾーンのチェック条件を修正する

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,16 +1,4 @@
 approvers:
-- munnerz
-- joshvanl
-- wallrj
-- jakexks
-- maelvls
-- irbekrm
-- inteon
+  - ophum
 reviewers:
-- munnerz
-- joshvanl
-- wallrj
-- jakexks
-- maelvls
-- irbekrm
-- inteon
+  - ophum

--- a/deploy/cert-manager-webhook-sakuracloud/Chart.yaml
+++ b/deploy/cert-manager-webhook-sakuracloud/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "v0.4.7"
+appVersion: "v0.4.8"
 description: A Helm chart for Kubernetes
 name: cert-manager-webhook-sakuracloud
-version: 0.4.7
+version: 0.4.8

--- a/deploy/cert-manager-webhook-sakuracloud/values.yaml
+++ b/deploy/cert-manager-webhook-sakuracloud/values.yaml
@@ -14,7 +14,7 @@ certManager:
 
 image:
   repository: ghcr.io/ophum/cert-manager-webhook-sakuracloud
-  tag: v0.4.7
+  tag: v0.4.8
   pullPolicy: IfNotPresent
 
 nameOverride: ""

--- a/main.go
+++ b/main.go
@@ -172,11 +172,6 @@ func (c *sakuraCloudDNSProviderSolver) getEntry(ch *v1alpha1.ChallengeRequest, z
 	if zoneName[len(zoneName)-1] != '.' {
 		zoneName += "."
 	}
-	// ResolvedZoneが一致する or ResolvedFQDNがzoneに含まれる場合を正常とする
-	if zoneName != ch.ResolvedZone && !strings.HasSuffix(ch.ResolvedFQDN, zoneName) {
-		return "", fmt.Errorf("invalid zone, resolvedZone: %s, zoneName: %s", ch.ResolvedZone, zoneName)
-	}
-
 	entry, ok := strings.CutSuffix(ch.ResolvedFQDN, "."+zoneName)
 	if !ok {
 		return "", fmt.Errorf("invalid fqdn, resolvedFQDN: %s, zoneName: %s", ch.ResolvedFQDN, zoneName)

--- a/main.go
+++ b/main.go
@@ -172,7 +172,8 @@ func (c *sakuraCloudDNSProviderSolver) getEntry(ch *v1alpha1.ChallengeRequest, z
 	if zoneName[len(zoneName)-1] != '.' {
 		zoneName += "."
 	}
-	if !strings.HasSuffix(ch.ResolvedZone, zoneName) {
+	// ResolvedZoneが一致する or ResolvedFQDNがzoneに含まれる場合を正常とする
+	if zoneName != ch.ResolvedZone && !strings.HasSuffix(ch.ResolvedFQDN, zoneName) {
 		return "", fmt.Errorf("invalid zone, resolvedZone: %s, zoneName: %s", ch.ResolvedZone, zoneName)
 	}
 


### PR DESCRIPTION
zone = test.example.com.
host = test.example.com.の場合に
ResolvedZoneがexample.com.となり失敗するため、ResolvedZoneが一致する場合またはResolvedFQDNがzoneのSuffixを持つ場合を正常とする
